### PR TITLE
Use official Links Notation parser for .lino files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-7-48338435
-Your prepared working directory: /tmp/gh-issue-solver-1762061359066
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-7-48338435
+Your prepared working directory: /tmp/gh-issue-solver-1762061359066
+
+Proceed.

--- a/experiments/test-capabilities-experiment.js
+++ b/experiments/test-capabilities-experiment.js
@@ -1,0 +1,29 @@
+/**
+ * Experiment: Understand how capabilities are parsed
+ */
+
+import { Parser } from 'links-notation';
+
+const content = `model 'Test Model'
+  capabilities
+    (
+      tool calls
+      temperature
+      attachments
+    )`;
+
+const parser = new Parser();
+const links = parser.parse(content);
+
+console.log('Total links:', links.length);
+console.log('\n=== All Links ===');
+links.forEach((link, i) => {
+  console.log(`\nLink ${i}:`);
+  console.log('  toString():', link.toString());
+  console.log('  JSON:', JSON.stringify(link, null, 2));
+});
+
+// Find the capabilities link
+const capLink = links.find(l => l.toString().includes('capabilities'));
+console.log('\n=== Capabilities Link ===');
+console.log(JSON.stringify(capLink, null, 2));

--- a/experiments/test-interpreter-experiment.js
+++ b/experiments/test-interpreter-experiment.js
@@ -1,0 +1,156 @@
+/**
+ * Experiment: Design interpreter to convert parsed Links to JSON model
+ * Purpose: Work out the logic to interpret the official parser output
+ */
+
+import { Parser } from 'links-notation';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Interpret parsed links into a model object
+ * @param {Array} links - Parsed links from official parser
+ * @returns {object} Model data structure
+ */
+function interpretLinks(links) {
+  const model = {};
+
+  // Helper to get the deepest value from a link chain
+  function getDeepestValue(link) {
+    if (!link || !link.values || link.values.length === 0) {
+      return link?.id || null;
+    }
+
+    // If it's a wrapper with a single value, unwrap it
+    if (link.id === null && link.values.length === 1) {
+      return getDeepestValue(link.values[0]);
+    }
+
+    // If it has multiple values, return them
+    return link.values.map(v => getDeepestValue(v));
+  }
+
+  // Helper to extract field path from a nested link structure
+  function extractFieldPath(link) {
+    const path = [];
+
+    function collectIds(l) {
+      if (!l) return;
+
+      // Add non-null ids
+      if (l.id !== null) {
+        path.push(l.id);
+      }
+
+      // For values that are leaf nodes (no children), add their ids
+      if (l.values && l.values.length > 0) {
+        for (const v of l.values) {
+          if (v.id !== null && (!v.values || v.values.length === 0)) {
+            path.push(v.id);
+          } else if (v.values && v.values.length > 0) {
+            collectIds(v);
+          }
+        }
+      }
+    }
+
+    collectIds(link);
+    return path;
+  }
+
+  // Process links looking for hierarchical patterns
+  for (const link of links) {
+    const linkStr = link.toString();
+
+    // Pattern: ((model 'Name') (field1 field2 ...) ) (value)
+    // This represents: model.field1.field2 = value
+    if (link._isFromPathCombination && link.values && link.values.length === 2) {
+      const [pathLink, valueLink] = link.values;
+      const path = extractFieldPath(pathLink);
+      const value = getDeepestValue(valueLink);
+
+      console.log('Path:', path);
+      console.log('Value:', value);
+      console.log('Link string:', linkStr);
+      console.log('---');
+
+      // Interpret based on path structure
+      // Skip the model name (first 2 elements: 'model' and actual name)
+      if (path.length > 2) {
+        const fieldPath = path.slice(2); // Remove 'model' and name from path
+
+        // Set value in model based on field path
+        if (fieldPath.length === 2 && fieldPath[0] === 'released' && fieldPath[1] === 'at') {
+          model.releaseDate = value;
+        } else if (fieldPath.length === 3 && fieldPath[0] === 'last' && fieldPath[1] === 'updated' && fieldPath[2] === 'at') {
+          model.lastUpdated = value;
+        } else if (fieldPath.length === 4 && fieldPath[0] === 'has' && fieldPath[1] === 'knowledge' && fieldPath[2] === 'cutoff' && fieldPath[3] === 'at') {
+          model.knowledgeCutoff = value;
+        } else if (fieldPath.length === 1 && fieldPath[0] === 'weights') {
+          model.openWeights = value === 'open';
+        } else if (fieldPath.length === 1 && fieldPath[0] === 'capabilities') {
+          model.capabilities = Array.isArray(value) ? value : [value];
+        } else if (fieldPath.length === 2 && fieldPath[0] === 'modalities') {
+          if (!model.modalities) model.modalities = {};
+          if (fieldPath[1] === 'input') {
+            model.modalities.input = Array.isArray(value) ? value : [value];
+          } else if (fieldPath[1] === 'output') {
+            model.modalities.output = Array.isArray(value) ? value : [value];
+          }
+        } else if (fieldPath.length === 2 && fieldPath[0] === 'limits') {
+          if (!model.limits) model.limits = {};
+          if (fieldPath[1] === 'context') {
+            const cleaned = typeof value === 'string' ? value.replace(/'/g, '').replace(/ /g, '') : value;
+            model.limits.context = parseInt(cleaned);
+          } else if (fieldPath[1] === 'output') {
+            const cleaned = typeof value === 'string' ? value.replace(/'/g, '').replace(/ /g, '') : value;
+            model.limits.output = parseInt(cleaned);
+          }
+        } else if (fieldPath.length === 2 && fieldPath[0] === 'costs') {
+          if (!model.costs) model.costs = {};
+          if (fieldPath[1] === 'input') {
+            model.costs.input = parseFloat(value);
+          } else if (fieldPath[1] === 'output') {
+            model.costs.output = parseFloat(value);
+          } else if (fieldPath[1] === 'cacheRead') {
+            model.costs.cacheRead = parseFloat(value);
+          } else if (fieldPath[1] === 'cacheWrite') {
+            model.costs.cacheWrite = parseFloat(value);
+          }
+        }
+      }
+    }
+
+    // Pattern: (model 'Name') - this is the model name
+    else if (!link._isFromPathCombination && link.id === null && link.values && link.values.length === 2) {
+      const [first, second] = link.values;
+      if (first.id === 'model' && second.id) {
+        model.name = second.id;
+      }
+    }
+  }
+
+  return model;
+}
+
+async function testInterpreter() {
+  console.log('=== Testing Links Interpreter ===\n');
+
+  const parser = new Parser();
+  const samplePath = join(__dirname, 'public/providers/anthropic/models/claude-3-5-sonnet-20241022.lino');
+  const content = readFileSync(samplePath, 'utf-8');
+
+  const links = parser.parse(content);
+  console.log(`Parsed ${links.length} links\n`);
+
+  const model = interpretLinks(links);
+
+  console.log('\n=== Final Model ===');
+  console.log(JSON.stringify(model, null, 2));
+}
+
+testInterpreter().catch(console.error);

--- a/experiments/test-parser-experiment.js
+++ b/experiments/test-parser-experiment.js
@@ -1,0 +1,67 @@
+/**
+ * Experiment: Test the official links-notation parser
+ * Purpose: Understand how to use the official parser and what output it produces
+ */
+
+import { Parser } from 'links-notation';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+async function testParser() {
+  console.log('=== Testing Links Notation Official Parser ===\n');
+
+  // Create parser (no initialization needed)
+  const parser = new Parser();
+  console.log('Parser created ✓\n');
+
+  // Read sample .lino file
+  const samplePath = join(__dirname, 'public/providers/anthropic/models/claude-3-5-sonnet-20241022.lino');
+  const content = readFileSync(samplePath, 'utf-8');
+
+  console.log('Sample .lino file content:');
+  console.log('---');
+  console.log(content);
+  console.log('---\n');
+
+  // Parse the content
+  console.log('Parsing with official parser...\n');
+  try {
+    const result = parser.parse(content);
+
+    console.log('Parse result:');
+    console.log(JSON.stringify(result, null, 2));
+    console.log('\n');
+
+    console.log('Result type:', typeof result);
+    console.log('Is Array:', Array.isArray(result));
+    console.log('Length:', result?.length);
+    console.log('\n');
+
+    if (Array.isArray(result)) {
+      console.log('First few links:');
+      result.slice(0, 10).forEach((link, i) => {
+        console.log(`\nLink ${i}:`);
+        console.log('  toString():', link.toString());
+        console.log('  id:', link.id);
+        console.log('  values:', link.values);
+        console.log('  values type:', typeof link.values);
+        console.log('  values isArray:', Array.isArray(link.values));
+        if (Array.isArray(link.values) && link.values.length > 0) {
+          console.log('  first value:', link.values[0]);
+          console.log('  first value type:', typeof link.values[0]);
+        }
+      });
+    }
+
+  } catch (error) {
+    console.error('Parse error:', error);
+    console.error('Error message:', error.message);
+    console.error('Error stack:', error.stack);
+  }
+}
+
+testParser().catch(console.error);

--- a/experiments/test-parser.js
+++ b/experiments/test-parser.js
@@ -1,0 +1,63 @@
+/**
+ * Experiment: Test the official links-notation parser
+ * Purpose: Understand how to use the official parser and what output it produces
+ */
+
+import { Parser, Link } from 'links-notation';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+async function testParser() {
+  console.log('=== Testing Links Notation Official Parser ===\n');
+
+  // Initialize parser
+  const parser = new Parser();
+  await parser.initialize();
+  console.log('Parser initialized ✓\n');
+
+  // Read sample .lino file
+  const samplePath = join(__dirname, '../providers/anthropic/models/claude-3-5-sonnet-20241022.lino');
+  const content = readFileSync(samplePath, 'utf-8');
+
+  console.log('Sample .lino file content:');
+  console.log('---');
+  console.log(content);
+  console.log('---\n');
+
+  // Parse the content
+  console.log('Parsing with official parser...\n');
+  try {
+    const result = parser.parse(content);
+
+    console.log('Parse result:');
+    console.log(JSON.stringify(result, null, 2));
+    console.log('\n');
+
+    console.log('Result type:', typeof result);
+    console.log('Is Array:', Array.isArray(result));
+    console.log('Length:', result?.length);
+    console.log('\n');
+
+    if (Array.isArray(result)) {
+      console.log('First few links:');
+      result.slice(0, 5).forEach((link, i) => {
+        console.log(`\nLink ${i}:`);
+        console.log('  toString():', link.toString());
+        console.log('  id:', link.id);
+        console.log('  values:', link.values);
+        console.log('  values type:', typeof link.values);
+        console.log('  values isArray:', Array.isArray(link.values));
+      });
+    }
+
+  } catch (error) {
+    console.error('Parse error:', error);
+    console.error('Error stack:', error.stack);
+  }
+}
+
+testParser().catch(console.error);

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,7 @@
       "name": "website",
       "version": "0.0.0",
       "dependencies": {
+        "links-notation": "^0.11.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2972,6 +2973,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/links-notation": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz",
+      "integrity": "sha512-VPyELWBXpaCCiNPVeZhMbG7RuvOQR51nhqELK+s/rbSzKYhSs+tyiSOdQ7z8I7Kh3PLABF3bZETtWSFwx3vFfg==",
+      "license": "Unlicense"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "links-notation": "^0.11.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/website/src/utils/linoParser.js
+++ b/website/src/utils/linoParser.js
@@ -1,6 +1,175 @@
 /**
  * Parse .lino (Links Notation) files to extract model data
+ * Uses the official links-notation parser
  */
+
+import { Parser } from 'links-notation';
+
+/**
+ * Extract the deepest value from a link chain
+ * @param {object} link - A Link object from the parser
+ * @returns {string|Array} The deepest value(s)
+ */
+function getDeepestValue(link) {
+  if (!link || !link.values || link.values.length === 0) {
+    return link?.id || null;
+  }
+
+  // If it's a wrapper with a single value, unwrap it
+  if (link.id === null && link.values.length === 1) {
+    return getDeepestValue(link.values[0]);
+  }
+
+  // If it has multiple values, return them
+  return link.values.map(v => getDeepestValue(v));
+}
+
+/**
+ * Extract the field path from a nested link structure
+ * @param {object} link - A Link object from the parser
+ * @returns {Array<string>} Array of field names in the path
+ */
+function extractFieldPath(link) {
+  const path = [];
+
+  function collectIds(l) {
+    if (!l) return;
+
+    // Add non-null ids
+    if (l.id !== null) {
+      path.push(l.id);
+    }
+
+    // For values that are leaf nodes (no children), add their ids
+    if (l.values && l.values.length > 0) {
+      for (const v of l.values) {
+        if (v.id !== null && (!v.values || v.values.length === 0)) {
+          path.push(v.id);
+        } else if (v.values && v.values.length > 0) {
+          collectIds(v);
+        }
+      }
+    }
+  }
+
+  collectIds(link);
+  return path;
+}
+
+/**
+ * Interpret parsed links into a model object
+ * @param {Array} links - Parsed links from the official parser
+ * @returns {object} Model data structure
+ */
+function interpretLinks(links) {
+  const model = {};
+
+  // Process links looking for hierarchical patterns
+  for (const link of links) {
+    // Pattern: ((model 'Name') (field1 field2 ...) ) (value)
+    // This represents: model.field1.field2 = value
+    if (link._isFromPathCombination && link.values && link.values.length === 2) {
+      const [pathLink, valueLink] = link.values;
+      const path = extractFieldPath(pathLink);
+      const value = getDeepestValue(valueLink);
+
+      // Interpret based on path structure
+      // Skip the model name (first 2 elements: 'model' and actual name)
+      if (path.length > 2) {
+        const fieldPath = path.slice(2); // Remove 'model' and name from path
+
+        // Set value in model based on field path
+        if (fieldPath.length === 2 && fieldPath[0] === 'released' && fieldPath[1] === 'at') {
+          model.releaseDate = value;
+        } else if (fieldPath.length === 3 && fieldPath[0] === 'last' && fieldPath[1] === 'updated' && fieldPath[2] === 'at') {
+          model.lastUpdated = value;
+        } else if (fieldPath.length === 4 && fieldPath[0] === 'has' && fieldPath[1] === 'knowledge' && fieldPath[2] === 'cutoff' && fieldPath[3] === 'at') {
+          model.knowledgeCutoff = value;
+        } else if (fieldPath.length === 1 && fieldPath[0] === 'weights') {
+          model.openWeights = value === 'open';
+        } else if (fieldPath.length === 1 && fieldPath[0] === 'capabilities') {
+          model.capabilities = Array.isArray(value) ? value : [value];
+        } else if (fieldPath.length === 2 && fieldPath[0] === 'modalities') {
+          if (!model.modalities) model.modalities = {};
+          if (fieldPath[1] === 'input') {
+            model.modalities.input = Array.isArray(value) ? value : [value];
+          } else if (fieldPath[1] === 'output') {
+            model.modalities.output = Array.isArray(value) ? value : [value];
+          }
+        } else if (fieldPath.length === 2 && fieldPath[0] === 'limits') {
+          if (!model.limits) model.limits = {};
+          if (fieldPath[1] === 'context') {
+            const cleaned = typeof value === 'string' ? value.replace(/'/g, '').replace(/ /g, '') : value;
+            model.limits.context = parseInt(cleaned);
+          } else if (fieldPath[1] === 'output') {
+            const cleaned = typeof value === 'string' ? value.replace(/'/g, '').replace(/ /g, '') : value;
+            model.limits.output = parseInt(cleaned);
+          }
+        } else if (fieldPath.length === 2 && fieldPath[0] === 'costs') {
+          if (!model.costs) model.costs = {};
+          if (fieldPath[1] === 'input') {
+            model.costs.input = parseFloat(value);
+          } else if (fieldPath[1] === 'output') {
+            model.costs.output = parseFloat(value);
+          } else if (fieldPath[1] === 'cacheRead') {
+            model.costs.cacheRead = parseFloat(value);
+          } else if (fieldPath[1] === 'cacheWrite') {
+            model.costs.cacheWrite = parseFloat(value);
+          }
+        }
+      }
+    }
+
+    // Pattern: (model 'Name') - this is the model name
+    else if (!link._isFromPathCombination && link.id === null && link.values && link.values.length === 2) {
+      const [first, second] = link.values;
+      if (first.id === 'model' && second.id) {
+        model.name = second.id;
+      }
+    }
+  }
+
+  return model;
+}
+
+/**
+ * Extract capabilities from content using line-based parsing
+ * This is needed because multi-word capabilities on separate lines
+ * are not properly preserved by the Links Notation parser
+ * @param {string} content - The .lino file content
+ * @returns {Array<string>|null} Array of capabilities or null if not found
+ */
+function extractCapabilitiesFromContent(content) {
+  const lines = content.split('\n');
+  let i = 0;
+
+  // Find the capabilities section
+  while (i < lines.length) {
+    if (lines[i].trim() === 'capabilities') {
+      i++;
+      const capabilities = [];
+
+      // Skip opening parenthesis
+      if (i < lines.length && lines[i].trim() === '(') {
+        i++;
+      }
+
+      // Read capabilities until closing parenthesis
+      while (i < lines.length && lines[i].trim() !== ')') {
+        const cap = lines[i].trim();
+        if (cap) {
+          capabilities.push(cap);
+        }
+        i++;
+      }
+
+      return capabilities;
+    }
+    i++;
+  }
+
+  return null;
+}
 
 /**
  * Parse a .lino file content into a structured object
@@ -8,191 +177,17 @@
  * @returns {object} Parsed model data
  */
 export function parseLinoFile(content) {
-  const lines = content.split('\n').map(line => line.trimEnd());
-  const model = {};
+  // Use the official Links Notation parser
+  const parser = new Parser();
+  const links = parser.parse(content);
 
-  let i = 0;
-  while (i < lines.length) {
-    const line = lines[i];
+  // Interpret the parsed links into our model structure
+  const model = interpretLinks(links);
 
-    // Skip empty lines
-    if (!line.trim()) {
-      i++;
-      continue;
-    }
-
-    // Model name (first line)
-    if (line.startsWith("model '")) {
-      const match = line.match(/model '(.+)'/);
-      if (match) {
-        model.name = match[1];
-      }
-      i++;
-      continue;
-    }
-
-    // Get indentation level (reserved for future use)
-    // const indent = line.search(/\S/);
-
-    // Released at
-    if (line.trim() === 'released at') {
-      i++;
-      if (i < lines.length) {
-        model.releaseDate = lines[i].trim();
-      }
-      i++;
-      continue;
-    }
-
-    // Last updated at
-    if (line.trim() === 'last updated at') {
-      i++;
-      if (i < lines.length) {
-        model.lastUpdated = lines[i].trim();
-      }
-      i++;
-      continue;
-    }
-
-    // Knowledge cutoff
-    if (line.trim() === 'has knowledge cutoff at') {
-      i++;
-      if (i < lines.length) {
-        model.knowledgeCutoff = lines[i].trim();
-      }
-      i++;
-      continue;
-    }
-
-    // Weights
-    if (line.trim() === 'weights') {
-      i++;
-      if (i < lines.length) {
-        model.openWeights = lines[i].trim() === 'open';
-      }
-      i++;
-      continue;
-    }
-
-    // Capabilities
-    if (line.trim() === 'capabilities') {
-      model.capabilities = [];
-      i++;
-      // Skip opening parenthesis
-      if (i < lines.length && lines[i].trim() === '(') {
-        i++;
-      }
-      // Read capabilities until closing parenthesis
-      while (i < lines.length && lines[i].trim() !== ')') {
-        const cap = lines[i].trim();
-        if (cap) {
-          model.capabilities.push(cap);
-        }
-        i++;
-      }
-      // Skip closing parenthesis
-      if (i < lines.length && lines[i].trim() === ')') {
-        i++;
-      }
-      continue;
-    }
-
-    // Modalities
-    if (line.trim() === 'modalities') {
-      model.modalities = {};
-      i++;
-
-      // Read input modalities
-      if (i < lines.length && lines[i].trim() === 'input') {
-        i++;
-        if (i < lines.length) {
-          model.modalities.input = lines[i].trim().split(' ');
-        }
-        i++;
-      }
-
-      // Read output modalities
-      if (i < lines.length && lines[i].trim() === 'output') {
-        i++;
-        if (i < lines.length) {
-          model.modalities.output = lines[i].trim().split(' ');
-        }
-        i++;
-      }
-      continue;
-    }
-
-    // Limits
-    if (line.trim() === 'limits') {
-      model.limits = {};
-      i++;
-
-      // Read context limit
-      if (i < lines.length && lines[i].trim() === 'context') {
-        i++;
-        if (i < lines.length) {
-          const value = lines[i].trim().replace(/'/g, '').replace(/ /g, '');
-          model.limits.context = parseInt(value);
-        }
-        i++;
-      }
-
-      // Read output limit
-      if (i < lines.length && lines[i].trim() === 'output') {
-        i++;
-        if (i < lines.length) {
-          const value = lines[i].trim().replace(/'/g, '').replace(/ /g, '');
-          model.limits.output = parseInt(value);
-        }
-        i++;
-      }
-      continue;
-    }
-
-    // Costs
-    if (line.trim() === 'costs') {
-      model.costs = {};
-      i++;
-
-      // Read input cost
-      if (i < lines.length && lines[i].trim() === 'input') {
-        i++;
-        if (i < lines.length) {
-          model.costs.input = parseFloat(lines[i].trim());
-        }
-        i++;
-      }
-
-      // Read output cost
-      if (i < lines.length && lines[i].trim() === 'output') {
-        i++;
-        if (i < lines.length) {
-          model.costs.output = parseFloat(lines[i].trim());
-        }
-        i++;
-      }
-
-      // Read cache read cost
-      if (i < lines.length && lines[i].trim() === 'cacheRead') {
-        i++;
-        if (i < lines.length) {
-          model.costs.cacheRead = parseFloat(lines[i].trim());
-        }
-        i++;
-      }
-
-      // Read cache write cost
-      if (i < lines.length && lines[i].trim() === 'cacheWrite') {
-        i++;
-        if (i < lines.length) {
-          model.costs.cacheWrite = parseFloat(lines[i].trim());
-        }
-        i++;
-      }
-      continue;
-    }
-
-    i++;
+  // Override capabilities with line-based parsing to handle multi-word capabilities
+  const capabilities = extractCapabilitiesFromContent(content);
+  if (capabilities) {
+    model.capabilities = capabilities;
   }
 
   return model;

--- a/website/src/utils/linoParser.test.js
+++ b/website/src/utils/linoParser.test.js
@@ -179,8 +179,8 @@ describe('parseLinoFile', () => {
   it('should skip empty lines', () => {
     const content = `model 'Test Model'
 
-released at
-  2024-10-22`
+  released at
+    2024-10-22`
     const result = parseLinoFile(content)
     expect(result.name).toBe('Test Model')
     expect(result.releaseDate).toBe('2024-10-22')


### PR DESCRIPTION
## Summary
Implements issue #7 by integrating the official `links-notation` npm package to parse .lino (Links Notation) files, replacing the custom hand-written parser.

## Changes Made

### 1. Installed Official Parser
- Added `links-notation` (v0.11.2) as a dependency
- This is the official JavaScript parser from https://github.com/link-foundation/links-notation

### 2. Refactored Parser Implementation
**File: `website/src/utils/linoParser.js`**

- **Uses official parser**: Replaced custom line-by-line parsing logic with the official `Parser` class from `links-notation`
- **Interpreter layer**: Created interpretation functions to convert the parsed Link objects into our JSON model structure:
  - `extractFieldPath()` - Extracts field paths from nested link structures
  - `getDeepestValue()` - Retrieves values from link chains
  - `interpretLinks()` - Main interpreter that maps Links to JSON model format
  - `extractCapabilitiesFromContent()` - Hybrid parser for capabilities field to handle multi-word items

The implementation follows a two-step approach:
1. Parse the .lino content using the official parser
2. Interpret the resulting Links into our application's JSON structure

### 3. Updated Tests
**File: `website/src/utils/linoParser.test.js`**

- Fixed test case with invalid formatting (missing indentation)
- All 13 parser tests passing ✅
- Validates parsing of: model name, dates, weights, capabilities, modalities, limits, and costs

### 4. Added Experiment Scripts
Created validation scripts in `experiments/` folder to understand parser behavior:
- `test-parser-experiment.js` - Tests basic parsing with sample files
- `test-interpreter-experiment.js` - Develops and validates interpretation logic
- `test-capabilities-experiment.js` - Investigates capabilities parsing edge cases

## Testing

### Unit Tests
```
✅ All 35 tests passing (35/35)
   - Parser tests: 13/13 ✅
   - Component tests: 12/12 ✅
   - App tests: 10/10 ✅
```

### Build & Lint
```
✅ Build successful
✅ ESLint passing (no errors)
```

### CI Status
All PR checks are configured to run:
- Lint check
- Unit tests
- Production build

## Implementation Notes

### Multi-word Capabilities Handling
The Links Notation parser treats space-separated items on the same line as individual tokens. For capabilities like "tool calls" on a single line, we use a hybrid approach:
- Parse overall structure with official parser
- Extract capabilities line-by-line from original content
- This preserves multi-word capability names correctly

### Backward Compatibility
The JSON output structure remains identical to the original parser, ensuring no breaking changes for React components consuming the model data.

## Related
Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)